### PR TITLE
Update Submodules flag & Tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ The script expects two arguments:
 `modifyVersions.py [version] {remove_snapshot, bump_to_snapshot}`
 
 * **version:** The version string for the current release. This will be used to determine which release branches should be changed (ex. 6.1.4)
-* **remove_snapshot** or **bump_to_version**: This determines which operation should be performed: 
+* **remove_snapshot**, **bump_to_version** or **update_submodules**: This determines which operation should be performed: 
 
-  * **remove_snapshot**:  This should be run **before** a release. This will ensure all `-SNAPSHOT` versions are updated to the next non-SNAPSHOT version in preparation for building and releasing.
-  * **bump_to_snapshot**:  This should be run **after** a release. This will ensure all versions are updated to the next `-SNAPSHOT` version to allow development to continue on that branch for the next patch release
+  * **remove_snapshot**:  This should be run **before** a release. This will ensure all `-SNAPSHOT` versions are updated to the next non-SNAPSHOT version in preparation for building and releasing. This operation also runs update_submodules to ensure everything is synced.
+  * **bump_to_snapshot**:  This should be run **after** a release. This will ensure all versions are updated to the next `-SNAPSHOT` version to allow development to continue on that branch for the next patch release. This operation also runs update_submodules to ensure everything is synced.
+  * **update_submodules**:  This can be run at any time. This will update the submodules in all repos to use the newest commit from their respective repo and branch. 
 
 ## Generate Release Notes
 The **[generateReleaseNotes](/generateReleaseNotes.py)** script automatically extracts Release Notes from all JIRA tickets targeted for this release and compiles the result into a reStructuredText file (`.rst`). A small example of the generated rst file can be seen below:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The **[modifyVersions](/modifyVersions.py)** script automatically bumps versions
 ### Usage
 The script expects two arguments:
 
-`modifyVersions.py [version] {remove_snapshot, bump_to_snapshot}`
+`modifyVersions.py [version] {remove_snapshot, bump_to_snapshot, update_submodules}`
 
 * **version:** The version string for the current release. This will be used to determine which release branches should be changed (ex. 6.1.4)
 * **remove_snapshot**, **bump_to_version** or **update_submodules**: This determines which operation should be performed: 

--- a/git.py
+++ b/git.py
@@ -229,6 +229,17 @@ def pushAndCreatePR(repo, title, body, currentBranch, targetBranch, outputURLToF
     if not outputURLToFile:
         return prLink  # Return PR URL
 
+def tagRepo(repo, tag):
+    print("Tagging repo %s with tag '%s'"%(repo, tag))
+    commands = []
+    repoPath = getRepoPath(repo)
+    commands.append('cd "%s"' % repoPath)
+    commands.append('git tag %s'%tag)
+    commands.append('git push origin %s'%tag)
+    code = call(" && ".join(commands), shell=True)
+    if code != 0:
+        print("Failed to tag repo, tag probably already exists")
+
 
 def deleteLocalRepo(repo):
     """ Deletes the local copy of the repo to force-remove all local changes """


### PR DESCRIPTION
This PR adds the following two requested features:

- Ability to automatically update submodules at any time without needing to run the version bump scripts
- Script will automatically tag the repo with the release version before bumping to the next snapshot version