### PR TITLE
Add metrics and event writer extension to repo list

### DIFF
--- a/repos.txt
+++ b/repos.txt
@@ -16,3 +16,5 @@ data-integrations/datastream-delta-plugins
 data-integrations/delta-transformation
 data-integrations/database-plugins
 cdapio/cdap-ui
+cdapio/metrics-writer-extension
+cdapio/events-writer-extension


### PR DESCRIPTION

Both are present in https://github.com/cdapio/cdap-build/blob/develop/.gitmodules